### PR TITLE
Add draft specification - filter

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1,0 +1,219 @@
+openapi: 3.0.3
+info:
+  title: STAC API - Item Collection
+  version: xxx
+  description: >-
+    This is an OpenAPI definition of the SpatioTemporal Asset Catalog API - Collection Search
+    specification.
+  contact:
+    name: STAC Specification
+    url: 'http://stacspec.org'
+  license:
+    name: Apache License 2.0
+    url: 'http://www.apache.org/licenses/LICENSE-2.0'
+tags:
+  - name: Core
+    description: Part of STAC API - Core definition
+  - name: Collections
+    description: Extension of the collections specification - Collection search definition
+
+paths:
+  /collections:
+    get:
+      summary: Search STAC collections with simple filtering
+      operationId: getCollectionSearch
+      description: |-
+        Retrieve Collections matching filters. Intended as a shorthand API for simple
+        queries.
+
+        This method is required to implement.
+
+        If this endpoint is implemented on a server, it is required to add a
+        link referring to this endpoint with `rel` set to `search` to the
+        `links` array in `GET /`. As `GET` is the default method, the `method`
+        may not be set explicitly in the link.
+      tags:
+        - Collection Search
+      parameters:
+        - $ref: '#/components/parameters/bbox'
+        - $ref: '#/components/parameters/datetime'
+        - $ref: '#/components/parameters/limit'
+        - $ref: '#/components/parameters/ids'
+      responses:
+        '200':
+          $ref: '#/components/responses/Collections'
+        '500':
+          $ref: '#/components/responses/ServerError'
+        default:
+          $ref: '../core/commons.yaml#/components/responses/Error'
+components:
+  parameters:
+    ids:
+      name: ids
+      in: query
+      description: |-
+        Array of Collection ids to return.
+      required: false
+      schema:
+        $ref: '#/components/schemas/ids'
+      explode: false
+    datetime:
+      name: datetime
+      in: query
+      description: |-
+        Either a date-time or an interval, open or closed. Date and time expressions
+        adhere to RFC 3339. Open intervals are expressed using double-dots.
+        Examples:
+        * A date-time: "2018-02-12T23:20:50Z"
+        * A closed interval: "2018-02-12T00:00:00Z/2018-03-18T12:31:12Z"
+        * Open intervals: "2018-02-12T00:00:00Z/.." or "../2018-03-18T12:31:12Z"
+        Only features that have a temporal property that intersects the value of
+        `datetime` are selected.
+        If a feature has multiple temporal properties, it is the decision of the
+        server whether only a single temporal property is used to determine
+        the extent or all relevant temporal properties.
+      required: false
+      schema:
+        type: string
+      style: form
+      explode: false
+    bbox:
+      name: bbox
+      in: query
+      description: |-
+        Only features that have a geometry that intersects the bounding box are selected.
+        The bounding box is provided as four or six numbers, depending on
+        whether the coordinate reference system includes a vertical axis (height
+        or depth):
+        * Lower left corner, coordinate axis 1
+        * Lower left corner, coordinate axis 2
+        * Minimum value, coordinate axis 3 (optional)
+        * Upper right corner, coordinate axis 1
+        * Upper right corner, coordinate axis 2
+        * Maximum value, coordinate axis 3 (optional)
+        The coordinate reference system of the values is WGS 84
+        longitude/latitude (http://www.opengis.net/def/crs/OGC/1.3/CRS84).
+        For WGS 84 longitude/latitude the values are in most cases the sequence
+        of minimum longitude, minimum latitude, maximum longitude and maximum
+        latitude. However, in cases where the box spans the antimeridian the
+        first value (west-most box edge) is larger than the third value
+        (east-most box edge).
+        If the vertical axis is included, the third and the sixth number are
+        the bottom and the top of the 3-dimensional bounding box.
+        If a feature has multiple spatial geometry properties, it is the
+        decision of the server whether only a single spatial geometry property
+        is used to determine the extent or all relevant geometries.
+        Example: The bounding box of the New Zealand Exclusive Economic Zone in
+        WGS 84 (from 160.6°E to 170°W and from 55.95°S to 25.89°S) would be
+        represented in JSON as `[160.6, -55.95, -170, -25.89]` and in a query as
+        `bbox=160.6,-55.95,-170,-25.89`.
+      required: false
+      schema:
+        type: array
+        oneOf:
+          - minItems: 4
+            maxItems: 4
+          - minItems: 6
+            maxItems: 6
+        items:
+          type: number
+      style: form
+      explode: false
+    limit:
+      name: limit
+      in: query
+      description: |-
+        The optional limit parameter recommends the number of collections that should be present in the response document.
+        Minimum = 1. Maximum = 10000. Default = 10.
+      required: false
+      schema:
+        type: integer
+        minimum: 1
+        maximum: 10000
+        default: 10
+      style: form
+      explode: false
+    intersects:
+      name: intersects
+      in: query
+      description: |-
+        The optional intersects parameter filters the result Collections in the same way as bbox, only with
+        a GeoJSON Geometry rather than a bbox.
+      required: false
+      schema:
+        $ref: '../core/commons.yaml#/components/schemas/geometryGeoJSON'
+      style: form
+      explode: false
+
+  schemas:
+    searchBody:
+      description: The search criteria
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/bboxFilter'
+        - $ref: '#/components/schemas/datetimeFilter'
+        - $ref: '#/components/schemas/intersectsFilter'
+        - $ref: '#/components/schemas/idsFilter'
+        - $ref: '#/components/schemas/limitFilter'
+    limit:
+      type: integer
+      minimum: 1
+      example: 10
+      default: 10
+      maximum: 10000
+      description: |-
+        The optional limit parameter limits the number of collections that are presented in the response document.
+        If the limit parameter value is greater than advertised limit maximum, the server must return the
+        maximum possible number of items, rather than responding with an error.
+        Minimum = 1. Maximum = 10000. Default = 10.
+    bboxFilter:
+      type: object
+      description: Only return collections that intersect the provided bounding box.
+      properties:
+        bbox:
+          $ref: '../core/commons.yaml#/components/schemas/bbox'
+    ids:
+      type: array
+      description: |-
+        Array of Collection ids to return.
+      items:
+        type: string
+    datetimeFilter:
+      description: An object representing a date+time based filter.
+      type: object
+      properties:
+        datetime:
+          $ref: '#/components/schemas/datetime_interval'
+    intersectsFilter:
+      type: object
+      description: Only returns collections that intersect with the provided polygon.
+      properties:
+        intersects:
+          $ref: '../core/commons.yaml#/components/schemas/geometryGeoJSON'
+    limitFilter:
+      type: object
+      description: Only returns maximum number of results (page size)
+      properties:
+        limit:
+          $ref: '#/components/schemas/limit'
+    idsFilter:
+      type: object
+      description: Only returns collections that match the array of given ids
+      properties:
+        ids:
+          $ref: '#/components/schemas/ids'
+    datetime_interval:
+      type: string
+      description: |-
+        Either a date-time or an interval, open or closed. Date and time expressions
+        adhere to RFC 3339. Open intervals are expressed using double-dots.
+        Examples:
+        * A date-time: "2018-02-12T23:20:50Z"
+        * A closed interval: "2018-02-12T00:00:00Z/2018-03-18T12:31:12Z"
+        * Open intervals: "2018-02-12T00:00:00Z/.." or "../2018-03-18T12:31:12Z"
+        Only features that have a temporal property that intersects the value of
+        `datetime` are selected.
+        If a feature has multiple temporal properties, it is the decision of the
+        server whether only a single temporal property is used to determine
+        the extent or all relevant temporal properties.
+      example: '2018-02-12T00:00:00Z/2018-03-18T12:31:12Z'

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -36,6 +36,7 @@ paths:
         - Collection Search
       parameters:
         - $ref: '#/components/parameters/bbox'
+        - $ref: '#/components/parameters/intersects'
         - $ref: '#/components/parameters/datetime'
         - $ref: '#/components/parameters/limit'
         - $ref: '#/components/parameters/ids'


### PR DESCRIPTION
This PR is intended at having a place for discussion on the `collection-search` specification. I prefer having the discussion here because comments can be linked to particular chunks of code.

Here I add the specification for filtering (search still needs to be added). Based largely on https://github.com/radiantearth/stac-api-spec/issues/145 and https://github.com/radiantearth/stac-api-spec/blob/main/item-search/openapi.yaml

I found the following issues:
- the implementation of the logic behind `intersects` and `bbox` will necessarily be different from the `/search` end point, because a collection does not have a geometry;
- the same applies to parameter `datetime`, since a collection doesn't have a datetime property, but rather a temporal extent.

